### PR TITLE
The quasi-quoters should only accept valid js

### DIFF
--- a/src/Language/ECMAScript3/Syntax/QuasiQuote.hs
+++ b/src/Language/ECMAScript3/Syntax/QuasiQuote.hs
@@ -35,10 +35,11 @@ quoteCommon :: Data a => Parser String a -> String -> TH.ExpQ
 quoteCommon p s = do loc <- TH.location
                      let fname = TH.loc_filename loc
                      let (line, col)  = TH.loc_start loc
-                     let p2 = (getPosition >>= \pos ->
-                                setPosition $ (flip setSourceName) fname $
-                                (flip setSourceLine) line $
-                                (flip setSourceColumn) col $ pos) >> p
+                     let p2 = do pos <- getPosition
+                                 setPosition $ (flip setSourceName) fname $
+                                   (flip setSourceLine) line $
+                                   (flip setSourceColumn) col $ pos
+                                 p
                      case parse p2 "" s of
                        Left err -> do TH.report True $ show err
                                       return $ TH.UnboxedTupE []

--- a/src/Language/ECMAScript3/Syntax/QuasiQuote.hs
+++ b/src/Language/ECMAScript3/Syntax/QuasiQuote.hs
@@ -39,7 +39,9 @@ quoteCommon p s = do loc <- TH.location
                                  setPosition $ (flip setSourceName) fname $
                                    (flip setSourceLine) line $
                                    (flip setSourceColumn) col $ pos
-                                 p
+                                 r <- p
+                                 eof
+                                 return r
                      case parse p2 "" s of
                        Left err -> do TH.report True $ show err
                                       return $ TH.UnboxedTupE []


### PR DESCRIPTION
Change `[jsexpr|x 2= 5|]` to produce an error rather than act like `[jsexpr|x |]`.