### PR TITLE
Javascript identifiers allow only BMP codepoints

### DIFF
--- a/language-ecmascript.cabal
+++ b/language-ecmascript.cabal
@@ -17,7 +17,7 @@ Category:       Language
 Build-Type:     Simple
 Synopsis:       JavaScript parser and pretty-printer library
 Description:
-  Tools for working with ECMAScript 3 (popularly known as JavaScript). 
+  Tools for working with ECMAScript 3 (popularly known as JavaScript).
   Includes a parser, pretty-printer, tools for working with source tree
   annotations and an arbitrary instance. See CHANGELOG for a summary of
   changes. The package follows the Haskell Package Versioning Policy since version 0.17.0.1.
@@ -45,12 +45,13 @@ Library
     QuickCheck >= 2.5 && < 3,
     template-haskell >= 2.7 && < 3,
     Diff == 0.3.*,
-    testing-feat >= 0.4.0.2 && < 0.5
+    testing-feat >= 0.4.0.2 && < 0.5,
+    charset >= 0.3
   ghc-options:
     -fwarn-incomplete-patterns
   Exposed-Modules:
-    Language.ECMAScript3 
-    Language.ECMAScript3.Lexer 
+    Language.ECMAScript3
+    Language.ECMAScript3.Lexer
     Language.ECMAScript3.Parser
     Language.ECMAScript3.PrettyPrint
     Language.ECMAScript3.Syntax

--- a/src/Language/ECMAScript3/Lexer.hs
+++ b/src/Language/ECMAScript3/Lexer.hs
@@ -13,6 +13,7 @@ module Language.ECMAScript3.Lexer(lexeme,identifier,reserved,operator,reservedOp
                                  ,hexIntLit,decIntLit, decDigits, decDigitsOpt, exponentPart, decLit) where
 
 import Prelude hiding (lex)
+import Data.Char
 import Text.Parsec
 import qualified Text.Parsec.Token as T
 import Language.ECMAScript3.Parser.State
@@ -21,8 +22,14 @@ import Control.Monad.Identity
 import Control.Applicative ((<$>), (<*>))
 import Data.Maybe (isNothing)
 
+jsLetter :: (Stream s m Char) => ParsecT s u m Char
+jsLetter = satisfy (\x ->  isAlpha x && x < '\65536') <?> "letter"
+
+jsAlphaNum :: (Stream s m Char => ParsecT s u m Char)
+jsAlphaNum = satisfy  (\x -> isAlphaNum x && x < '\65536') <?> "letter or digit"
+
 identifierStart :: Stream s Identity Char => Parser s Char
-identifierStart = letter <|> oneOf "$_"
+identifierStart = jsLetter <|> oneOf "$_"
 
 javascriptDef :: Stream s Identity Char =>T.GenLanguageDef s ParserState Identity
 javascriptDef =
@@ -31,7 +38,7 @@ javascriptDef =
                 "//"
                 False -- no nested comments
                 identifierStart
-                (alphaNum <|> oneOf "$_") -- identifier rest
+                (jsAlphaNum <|> oneOf "$_") -- identifier rest
                 (oneOf "{}<>()~.,?:|&^=!+-*/%!") -- operator start
                 (oneOf "=<>|&+") -- operator rest
                 ["break", "case", "catch", "const", "continue", "debugger", 


### PR DESCRIPTION
I was hoping to use language-ecmascript with quickcheck to test the behavior of servant-js

At first I thought that the only thing that was missing from here was excluding non-BMP codepoints, but I then realized that servant-js code is more precise

I thus updated the code since, for example, valid identifiers like `"a\65075"` aren't correctly parsed
