### PR TITLE
Adjust base upper boundary for base for tests

### DIFF
--- a/language-ecmascript.cabal
+++ b/language-ecmascript.cabal
@@ -86,7 +86,7 @@ Test-Suite test
     Test.Pretty
     Test.Arbitrary
   Build-Depends:
-    base >= 4 && < 4.14,
+    base >= 4 && < 4.15,
     mtl >= 1 && < 3,
     parsec >= 3 && < 3.2.0,
     ansi-wl-pprint >= 0.6 && < 1,


### PR DESCRIPTION
A new release with this would be appreciated since we usually run the test suite for haskell packages in nixos :)