### PR TITLE
Bump various dependencies including base

### DIFF
--- a/language-ecmascript.cabal
+++ b/language-ecmascript.cabal
@@ -35,16 +35,16 @@ Library
   Hs-Source-Dirs:
     src
   Build-Depends:
-    base >= 4 && < 4.19,
+    base >= 4 && < 4.21,
     mtl >= 1 && < 3,
     parsec > 3 && < 3.2.0,
-    ansi-wl-pprint >= 0.6 && < 1,
+    ansi-wl-pprint >= 0.6 && < 1.1,
     containers == 0.*,
     uniplate >= 1.6 && <1.7,
     data-default-class >= 0.0.1 && < 0.2,
     QuickCheck >= 2.5 && < 3,
     template-haskell >= 2.7 && < 3,
-    Diff == 0.4.*,
+    Diff >= 0.4 && < 0.6,
     charset >= 0.3
   ghc-options:
     -fwarn-incomplete-patterns
@@ -93,7 +93,7 @@ Test-Suite test
     charset >= 0.3,
     containers,
     directory >= 1.2 && < 1.4,
-    filepath >= 1.3 && < 1.5,
+    filepath >= 1.3 && < 1.6,
     HUnit >= 1.2 && < 1.7,
     QuickCheck >= 2.5 && < 3,
     data-default-class,


### PR DESCRIPTION
I've run the test suite constraining to the newer versions:

```
cabal test --constraint 'Diff>=0.5' --constraint 'ansi-wl-pprint>=1.0' --constraint 'base>=4.20' --constraint 'filepath>=1.5'
```